### PR TITLE
Fix typescript nullability error

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -83,10 +83,10 @@ function App() {
         if (amplifyReleases && amplifyReleases.length > 0) {
           setReleases(amplifyReleases.map(release => ({
             id: release.id,
-            mainVersion: release.mainVersion,
-            goLiveDate: release.goLiveDate,
-            frameworkVersion: release.frameworkVersion,
-            released: release.released,
+            mainVersion: release.mainVersion ?? '',
+            goLiveDate: release.goLiveDate ?? '',
+            frameworkVersion: release.frameworkVersion ?? '',
+            released: release.released ?? false,
           })));
         }
       } catch (error) {


### PR DESCRIPTION
Fix TypeScript build error by providing default values for nullable fields when mapping Amplify data.

The build failed due to a `TS2345` error where `Nullable<string>` and `Nullable<boolean>` types from Amplify data were not assignable to the non-nullable `string` and `boolean` types expected by the `SoftwareRelease` interface. This PR resolves the issue by using the nullish coalescing operator (`??`) to provide default empty strings or `false` for these fields, ensuring type compatibility.